### PR TITLE
Fix fake errors on file unmapping

### DIFF
--- a/tbprobe.c
+++ b/tbprobe.c
@@ -234,7 +234,7 @@ static void *map_file(FD fd, map_t *mapping)
 static void unmap_file(void *data, map_t size)
 {
   if (!data) return;
-  if (!munmap(data, size)) {
+  if (munmap(data, size) < 0) {
 	  perror("munmap");
   }
 }


### PR DESCRIPTION
Fix the munmap() verification when unmapping regions, since it returns 0 when successful and a negative number in case of failure.