### PR TITLE
Fix reinit after free

### DIFF
--- a/tbprobe.c
+++ b/tbprobe.c
@@ -639,8 +639,6 @@ bool tb_init(const char *path)
     LOCK_DESTROY(tbMutex);
 
     pathString = NULL;
-    pieceEntry = NULL;
-    pawnEntry = NULL;
     numWdl = numDtm = numDtz = 0;
   }
 
@@ -796,6 +794,8 @@ void tb_free(void)
   tb_init("");
   free(pieceEntry);
   free(pawnEntry);
+  pieceEntry = NULL;
+  pawnEntry = NULL;
 }
 
 static const int8_t OffDiag[] = {

--- a/tbprobe.c
+++ b/tbprobe.c
@@ -639,6 +639,8 @@ bool tb_init(const char *path)
     LOCK_DESTROY(tbMutex);
 
     pathString = NULL;
+    pieceEntry = NULL;
+    pawnEntry = NULL;
     numWdl = numDtm = numDtz = 0;
   }
 


### PR DESCRIPTION
Sets `pieceEntry` and `pawnEntry` to `NULL` during `tb_free`, such that if `tb_init` is called again the arrays will be reallocated.

See #6 