### PR TITLE
remove calls to exit

### DIFF
--- a/tbprobe.c
+++ b/tbprobe.c
@@ -674,12 +674,8 @@ bool tb_init(const char *path)
     pawnEntry = (struct PawnEntry*)malloc(TB_MAX_PAWN * sizeof(*pawnEntry));
     if (!pieceEntry || !pawnEntry) {
       fprintf(stderr, "Out of memory.\n");
-      if (pieceEntry) {
-        free(pieceEntry);
-      }      
-      if (pawnEntry) {
-        free(pawnEntry);
-      }
+      free(pieceEntry);
+      free(pawnEntry);
       return false;
     }
   }

--- a/tbprobe.c
+++ b/tbprobe.c
@@ -494,7 +494,7 @@ static void *map_tb(const char *name, const char *suffix, map_t *mapping) {
     void *data = map_file(fd, mapping);
     if (data == NULL) {
         fprintf(stderr, "Could not map %s%s into memory.\n", name, suffix);
-        exit(EXIT_FAILURE);
+        return NULL;
     }
 
     close_tb(fd);
@@ -674,7 +674,13 @@ bool tb_init(const char *path)
     pawnEntry = (struct PawnEntry*)malloc(TB_MAX_PAWN * sizeof(*pawnEntry));
     if (!pieceEntry || !pawnEntry) {
       fprintf(stderr, "Out of memory.\n");
-      exit(EXIT_FAILURE);
+      if (pieceEntry) {
+        free(pieceEntry);
+      }      
+      if (pawnEntry) {
+        free(pawnEntry);
+      }
+      return false;
     }
   }
 


### PR DESCRIPTION
removes unnecessary calls to exit() and instead propagates errors to the caller